### PR TITLE
[DO NOT MERGE] bump components version

### DIFF
--- a/cmc/Chart.yaml
+++ b/cmc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CMC product
 name: cmc
-version: 0.0.3
+version: 0.0.4
 keywords:
   - cmc
   - civil-money-claims

--- a/cmc/requirements.yaml
+++ b/cmc/requirements.yaml
@@ -3,13 +3,15 @@ dependencies:
     version: ~5.3.0
     repository: '@stable'
   - name: cmc-claim-store
-    version: ~1.1.5
+    version: ~1.1.6
     repository: '@hmctspublic'
     # repository: file:///Users/markry/workspace/hmcts/cmc-claim-store/charts/cmc-claim-store
+    repository: file:///Users/kariml/Development/cmc-claim-store/charts/cmc-claim-store
   - name: cmc-citizen-frontend
-    version: ~1.0.7
+    version: ~1.0.8
     repository: '@hmctspublic'
     # repository: file:///Users/markry/workspace/hmcts/cmc-citizen-frontend/charts/cmc-citizen-frontend
+    repository: file:///Users/kariml/Development/cmc-citizen-frontend/charts/cmc-citizen-frontend
   - name: draft-store-service
     version: ~1.0.4
     repository: '@hmctspublic'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-4263

### Change description ###

bump components version to use hmctspublic from chart-ccd

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
