### PR TITLE
Bump db connections

### DIFF
--- a/cmc/Chart.yaml
+++ b/cmc/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for the HMCTS CMC product
 name: cmc
-version: 0.0.5
+version: 0.0.6
 keywords:
   - cmc
   - civil-money-claims

--- a/cmc/values.yaml
+++ b/cmc/values.yaml
@@ -219,7 +219,7 @@ rpe-service-auth-provider:
 
 postgresql:
   pgParameters:
-    maxConnections: 150
+    maxConnections: 300
   resources:
     requests:
       cpu: 25m


### PR DESCRIPTION

### Change description ###

Demo fails - lots new services spin up grabbing DB connections: 

```
Caused by: org.postgresql.util.PSQLException: FATAL: remaining connection slots are reserved for non-replication superuser connections\n\tat org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2468)\n\tat org.postgresql.core.v3.QueryExecutorImpl.readStartupMessages(QueryExecutorImpl.java:2587)\n\tat org.postgresql.core.v3.QueryExecutorImpl.<init>(QueryExecutorImpl.java:134)\n\tat org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:250)
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
